### PR TITLE
Fix freeze on bzip2 presence checking

### DIFF
--- a/make/photon/db/rpm_builder.sh
+++ b/make/photon/db/rpm_builder.sh
@@ -12,7 +12,7 @@ function checkdep {
 		exit 1
 	fi
 
-	if ! bzip2 --version &> /dev/null
+	if ! [ -x "$(command -v bzip2)" ]
 	then
 		echo "Need to install bzip2 first and run this script again."
 		exit 1


### PR DESCRIPTION
For some reason this script hangs on bzip2 presence checking
Steps to reproduce:
* Clone repo from master branch
* Run: make install COMPILETAG=compile_golangimage
* Wait until script will check that bzip2 is installed